### PR TITLE
Add support for background color

### DIFF
--- a/data.go
+++ b/data.go
@@ -83,7 +83,7 @@ func ParseHexColor(s string) (c color.RGBA, err error) {
 }
 
 func ColorToHex(c color.RGBA) (s string) {
-	return fmt.Sprintf("%X%X%X", c.R, c.G, c.B)
+	return fmt.Sprintf("%X%X%X%X%X%X", c.R/16, c.R%16, c.G/16, c.G%16, c.B/16, c.B%16)
 }
 
 // Options specifies transformations to be performed on the requested image.

--- a/transform.go
+++ b/transform.go
@@ -51,7 +51,8 @@ func Transform(img []byte, opt Options) ([]byte, error) {
 		return nil, err
 	}
 
-	if (opt.BackgroundColor != color.RGBA{} && format == "png" || format == "tiff") && opt.Format == "jpeg" {
+	// Set background if option is provided, source image format supports transparency and destination doesn't
+	if ((opt.BackgroundColor != color.RGBA{}) && (format == "png" || format == "tiff")) && opt.Format == "jpeg" {
 		ni := image.NewRGBA(m.Bounds())
 		bi := image.NewUniform(opt.BackgroundColor)
 		draw.Draw(ni, m.Bounds(), bi, image.Point{}, draw.Src)

--- a/transform.go
+++ b/transform.go
@@ -7,6 +7,8 @@ import (
 	"bytes"
 	"fmt"
 	"image"
+	"image/color"
+	"image/draw"
 	_ "image/gif" // register gif format
 	"image/jpeg"
 	"image/png"
@@ -47,6 +49,14 @@ func Transform(img []byte, opt Options) ([]byte, error) {
 	m, format, err := image.Decode(bytes.NewReader(img))
 	if err != nil {
 		return nil, err
+	}
+
+	if (opt.BackgroundColor != color.RGBA{} && format == "png" || format == "tiff") && opt.Format == "jpeg" {
+		ni := image.NewRGBA(m.Bounds())
+		bi := image.NewUniform(opt.BackgroundColor)
+		draw.Draw(ni, m.Bounds(), bi, image.Point{}, draw.Src)
+		draw.Draw(ni, m.Bounds(), m, image.Point{}, draw.Over)
+		m = ni
 	}
 
 	// apply EXIF orientation for jpeg and tiff source images. Read at most


### PR DESCRIPTION
- adds support for specifying background color when converting images
It's not very pretty but it works 🤷
There's the performance consideration of going through pixels, but I think (not sure how to measure) doing this is dwarfed by PNG decoding and JPG encoding, and also the added performance hit should be far outweighed by the reduction in transfer size. Also this all gets cached.

<img width="1440" alt="Screen Shot 2021-03-30 at 5 14 23 pm" src="https://user-images.githubusercontent.com/1019280/112942430-d1b16180-917b-11eb-88a6-0e2ac8f963b7.png">
<img width="1440" alt="Screen Shot 2021-03-30 at 5 14 34 pm" src="https://user-images.githubusercontent.com/1019280/112942436-d413bb80-917b-11eb-9ae9-1fba7efadf62.png">
